### PR TITLE
Perform OCR on OCR-only processes

### DIFF
--- a/ocrmypdf_easyocr/__init__.py
+++ b/ocrmypdf_easyocr/__init__.py
@@ -110,7 +110,11 @@ def _ocrThread(q: multiprocessing.Queue[Task], options):
                 useGPU = options.gpu
                 languages = [ISO_639_3_2[lang] for lang in options.languages]
                 reader = easyocr.Reader(languages, useGPU)
-            outputDict["output"] = reader.readtext(gray)
+            outputDict["output"] = reader.readtext(
+                gray,
+                batch_size=options.easyocr_batch_size,
+                workers=options.easyocr_workers
+            )
         except Exception as e:
             print(e)
             outputDict["output"] = ""
@@ -140,6 +144,8 @@ def add_options(parser):
         "EasyOCR", "Advanced control of EasyOCR"
     )
     easyocr_options.add_argument("--easyocr-no-gpu", action="store_false", dest="gpu")
+    easyocr_options.add_argument("--easyocr-batch-size", type=int, default=4)
+    easyocr_options.add_argument("--easyocr-workers", type=int, default=0)
 
 
 class EasyOCREngine(OcrEngine):

--- a/ocrmypdf_easyocr/__init__.py
+++ b/ocrmypdf_easyocr/__init__.py
@@ -16,7 +16,7 @@ import easyocr
 import pluggy
 from ocrmypdf import OcrEngine, hookimpl
 from ocrmypdf._exec import tesseract
-import time
+import traceback
 
 from ocrmypdf_easyocr._cv import detect_skew
 from ocrmypdf_easyocr._easyocr import tidy_easyocr_result
@@ -116,7 +116,7 @@ def _ocrThread(q: multiprocessing.Queue[Task], options):
                 workers=options.easyocr_workers
             )
         except Exception as e:
-            print(e)
+            traceback.print_exception(e)
             outputDict["output"] = ""
         finally:
             event.set()

--- a/ocrmypdf_easyocr/__init__.py
+++ b/ocrmypdf_easyocr/__init__.py
@@ -7,21 +7,25 @@ from __future__ import annotations
 
 import logging
 import os
-from multiprocessing import Semaphore
+import multiprocessing
+import multiprocessing.managers
+import threading
 
 import cv2 as cv
 import easyocr
 import pluggy
 from ocrmypdf import OcrEngine, hookimpl
 from ocrmypdf._exec import tesseract
+import time
 
 from ocrmypdf_easyocr._cv import detect_skew
 from ocrmypdf_easyocr._easyocr import tidy_easyocr_result
 from ocrmypdf_easyocr._pdf import easyocr_to_pikepdf
 
-log = logging.getLogger(__name__)
+from typing import Optional, Tuple
+import numpy.typing as npt
 
-GPU_SEMAPHORE = Semaphore(3)
+log = logging.getLogger(__name__)
 
 ISO_639_3_2: dict[str, str] = {
     "afr": "af",
@@ -89,11 +93,46 @@ ISO_639_3_2: dict[str, str] = {
     "vie": "vi",
 }
 
+Task = Tuple[npt.NDArray, multiprocessing.Value, threading.Event]
+
+def _ocrThread(q: multiprocessing.Queue[Task], options):
+    reader: Optional[easyocr.Reader] = None
+
+    # TODO: signal _ocrThread to quit after OCR completes.
+    while True:
+        (gray, outputDict, event) = q.get()
+
+
+        # Init reader on first OCR attempt: Wait until `options` variable is fully initialized.
+        # Note: `options` variable is on the same process with the main thread.
+        try:
+            if reader is None:
+                useGPU = options.gpu
+                languages = [ISO_639_3_2[lang] for lang in options.languages]
+                reader = easyocr.Reader(languages, useGPU)
+            outputDict["output"] = reader.readtext(gray)
+        except Exception as e:
+            print(e)
+            outputDict["output"] = ""
+        finally:
+            event.set()
+
 
 @hookimpl
 def initialize(plugin_manager: pluggy.PluginManager):
     pass
 
+
+@hookimpl
+def check_options(options):
+    m = multiprocessing.Manager()
+    q = multiprocessing.Queue(-1)
+    t = threading.Thread(target=_ocrThread, args=(q, options), daemon=True)
+    t.start()
+    options._easyocr_struct = {
+        "manager": m,
+        "queue": q
+    }
 
 @hookimpl
 def add_options(parser):
@@ -143,15 +182,19 @@ class EasyOCREngine(OcrEngine):
 
     @staticmethod
     def generate_pdf(input_file, output_pdf, output_text, options):
-        languages = [ISO_639_3_2[lang] for lang in options.languages]
-
         img = cv.imread(os.fspath(input_file))
         gray = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
-        with GPU_SEMAPHORE:
-            reader = easyocr.Reader(languages, gpu=options.gpu)
-            raw_results = reader.readtext(gray)
-        results = [tidy_easyocr_result(r) for r in raw_results]
 
+        s = options._easyocr_struct
+        manager: multiprocessing.managers.SyncManager = s["manager"]
+        queue: multiprocessing.Queue[Task] = s["queue"]
+        outputDict = manager.dict()
+        event = manager.Event()
+        queue.put((gray, outputDict, event))
+        event.wait()
+        raw_results = outputDict["output"]
+
+        results = [tidy_easyocr_result(r) for r in raw_results]
         text = " ".join([result.text for result in results])
         output_text.write_text(text)
 


### PR DESCRIPTION
Spawn multiple `_ocrProcess` process and do all the OCR job there

Caveats:

- pytorch is not thread-safe, so use of `multiprocessing` module is necessary
- OCR processes are NOT gracefully terminated. I don't know when to terminate them.


New options:

- `--easyocr-workers [number]`: # of OCR processes. VRAM usage increases proportionally. IDK if this could be reduced, as `EasyOCR` doesn't seem to be multiprocessing-safe
- `--easyocr-batch-size [number]`: Set `batch_size` parameter of easyocr. Don't expect a lot of performance gain, though.


## Before (See GPU usage)

<img width="640" alt="2024-01-22 14_46_20-" src="https://github.com/ocrmypdf/OCRmyPDF-EasyOCR/assets/775265/a627ddf4-29dc-4f5d-a81c-509e8cc3eb62">

## After (See GPU usage)

<img width="640" alt="2024-01-22 14_37_58-작업 관리자" src="https://github.com/ocrmypdf/OCRmyPDF-EasyOCR/assets/775265/11c77613-269e-40fc-93d5-0ba19c105b98">

> not a fair comparison: Old implementation wants to use 12GB of ram, so it doesn't fit in my 3060. New implementation allows you to configure the amount of ram you want.


I'm seeing a speedup of 4x, but this may vary for people with lots of VRAMs. Further testing needed.



Fixes #3