### PR TITLE
Make OpenCV work on headless machines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "easyocr>=1.7.0",
     "ocrmypdf>=14.2.1",
     "Pillow>=10.0.1",
-    "opencv-python>=4.8.0.74",
+    "opencv-python-headless>=4.8.0.74",
     "numpy>=1.20",
     "torch",
 ]


### PR DESCRIPTION
Basically what it says, will avoid error `ImportError: libGL.so.1: cannot open shared object file: No such file or directory` on `import cv2` instruction on most server machines