### PR TITLE
Store EasyOCR models in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jbarlow83/ocrmypdf
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl git ca-certificates \
+    curl git unzip ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Seed pip into the ocrmypdf venv
@@ -14,3 +14,10 @@ RUN set -eux; \
 RUN /app/.venv/bin/pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu124
 
 RUN /app/.venv/bin/pip install --no-cache-dir git+https://github.com/ocrmypdf/OCRmyPDF-EasyOCR.git
+
+RUN mkdir -p /root/.EasyOCR/model && \
+    cd /root/.EasyOCR/model && \
+    curl -fsSL -O https://github.com/JaidedAI/EasyOCR/releases/download/v1.3/latin_g2.zip && \
+    curl -fsSL -O https://github.com/JaidedAI/EasyOCR/releases/download/v1.3/english_g2.zip && \
+    curl -fsSL -O https://github.com/JaidedAI/EasyOCR/releases/download/pre-v1.1.6/craft_mlt_25k.zip && \
+    unzip '*.zip' && rm -f *.zip


### PR DESCRIPTION
Otherwise they are downloaded on every `docker run --rm`